### PR TITLE
removed unnecessary duplicated border-radius

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,9 +25,9 @@
     max-width: 450px;
     margin: 100px auto;
     border-radius: 24px;
+    overflow:hidden;
   }
   .card-img {
-    border-radius: 24px 24px 0 0;
     width: 100%;
     height: auto;
   }


### PR DESCRIPTION
if the container with border-radius has a overflow:hidden the image will correctly addapt to it's border-radius, is not neccessary to give it to the image